### PR TITLE
ServiceWorker.ss Update

### DIFF
--- a/templates/ServiceWorker.ss
+++ b/templates/ServiceWorker.ss
@@ -51,14 +51,15 @@ self.addEventListener('push', function (event) {
             icon: _data.icon,
             badge: _data.badge,
             tag: _data.tag,
-            vibrate: _data.vibrate
+            vibrate: _data.vibrate,
+	    data: _data.url
         })
     );
 });
 
 // Action when the user clicks on the notification
 self.addEventListener('notificationclick', function (event) {
-    event.notification.close();
+	notificationUrl = event.notification.data;
 	   event.waitUntil(
         clients.matchAll({ type: 'window', includeUncontrolled: true })
             .then(function(clientList) {
@@ -76,4 +77,5 @@ self.addEventListener('notificationclick', function (event) {
                 return clients.openWindow(notificationUrl);
             })
     );
+	event.notification.close();
 });


### PR DESCRIPTION
If the service worker gets turned off for any reason the notification url just defaults to "/".
This means that when any notificaiton is clicked it's  using the default notificationUrl = "/";
To fix this I made it so the notifications contain the url in the empty data field and pass it to the receiving notificationclick function.
The app now opens as expected and goes to the correct URL.

Took a loooooong time to get this one sorted. There is no example I could find on the internet replicating this issue.